### PR TITLE
Full submodule only

### DIFF
--- a/scripts/import_and_patch_translators.py
+++ b/scripts/import_and_patch_translators.py
@@ -35,40 +35,7 @@ def run(cmd, **kwargs):
 
 
 def ensure_repo():
-    # Ensure translators dir exists
-    (ROOT / "translators").mkdir(parents=True, exist_ok=True)
-
-    if TARGET.exists() and (TARGET / ".git").exists():
-        print("Found existing git repo at", TARGET)
-        print("Updating...")
-        run(["git", "-C", str(TARGET), "pull", "--ff-only"])
-        return
-
-    # Try to add as submodule if current repo is a git repo
-    if (ROOT / ".git").exists():
-        try:
-            run(["git", "submodule", "add", ZOTERO_REPO, str(TARGET)])
-            print("Added submodule at", TARGET)
-            return
-        except subprocess.CalledProcessError:
-            print("git submodule add failed, falling back to clone")
-
-    # Fallback to clone
-    if TARGET.exists():
-        print("Removing existing target and recloning")
-        for child in TARGET.iterdir():
-            try:
-                if child.is_file():
-                    child.unlink()
-                else:
-                    # naive rmdir
-                    import shutil
-
-                    shutil.rmtree(child)
-            except Exception:
-                pass
-    run(["git", "clone", ZOTERO_REPO, str(TARGET)])
-
+    run(["git", "submodule", "update", "--init"])
 
 def comment_initial_json(text: str) -> tuple[str, bool]:
     # If file already starts with // or /*, assume header is commented


### PR DESCRIPTION
### **User description**
I think, with https://github.com/JabRef/JabRef-Browser-Extension-fresh/blob/3dda587f6bda13193c40de964299e0ee1a529e98/.github/dependabot.yml#L22, we have an automatic update - and can rely on `git submodule` alone.

If someone forgot to clone `--recursive`, we call `git submodule update --init` to ensure that the most recent version is available.

---

Side track: Should we create a fork of the translators repository - and create the patches there? -- So that no contributor needs to run the python script?


___

### **PR Type**
Enhancement


___

### **Description**
- Simplify translator repository setup using git submodule

- Remove fallback clone logic and manual git operations

- Rely on automatic submodule updates via dependabot

- Reduce script complexity and maintenance burden


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Complex ensure_repo logic"] -->|Refactor| B["Single git submodule update"]
  B -->|Depends on| C["Dependabot auto-updates"]
  B -->|Requires| D["git submodule --init"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>import_and_patch_translators.py</strong><dd><code>Streamline translator repo setup to submodule only</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/import_and_patch_translators.py

<ul><li>Replaced 33 lines of complex repository setup logic with single <code>git </code><br><code>submodule update --init</code> call<br> <li> Removed fallback clone mechanism and manual git operations<br> <li> Eliminated directory creation, existence checks, and error handling <br>for multiple setup methods<br> <li> Simplified to rely on git submodule configuration and dependabot for <br>automatic updates</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/JabRef-Browser-Extension-fresh/pull/14/files#diff-b788dea50a023919b66c0af3a29f5017ecac7bac32953db9f71817053b7fb948">+1/-34</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

