### PR TITLE
Add a local cache for the tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -231,5 +231,6 @@ dist
 
 # End of https://www.toptal.com/developers/gitignore/api/intellij+all,node
 
+# Temporary files
 dist/
-
+test_cache/

--- a/test.js
+++ b/test.js
@@ -2,19 +2,23 @@
 // Test runner: executes runTranslatorOnHtml on the testCases defined in
 // translators/zotero/ScienceDirect.js
 
-const fs = require('fs');
-const path = require('path');
-const vm = require('vm');
-const util = require('util');
+import { createWriteStream, mkdirSync, existsSync, promises, readFileSync, readdir } from 'fs';
+import { join, dirname } from 'path';
+import { createContext, runInContext } from 'vm';
+import { inspect } from 'util';
+
+// Compute root directory compatible with ESM `import.meta.url` and
+// legacy CommonJS `__dirname`.
+const ROOT_DIR = (typeof __dirname !== 'undefined') ? __dirname : dirname(new URL(import.meta.url).pathname);
 
 // Create a log file and duplicate console output to it.
-const LOG_PATH = path.join(__dirname, 'test.log');
+const LOG_PATH = join(ROOT_DIR, 'test.log');
 try {
     // append mode so repeated runs accumulate; you can change to 'w' to overwrite
-    const logStream = fs.createWriteStream(LOG_PATH, { flags: 'a' });
+    const logStream = createWriteStream(LOG_PATH, { flags: 'a' });
     const writeLog = (...args) => {
         try {
-            const line = args.map(a => (typeof a === 'string' ? a : util.inspect(a, { depth: null }))).join(' ');
+            const line = args.map(a => (typeof a === 'string' ? a : inspect(a, { depth: null }))).join(' ');
             logStream.write(line + '\n');
         } catch (e) {
             // ignore logging errors
@@ -38,30 +42,93 @@ try {
     console.error('Failed to initialize log file', e && e.message ? e.message : e);
 }
 
+// Directory to cache fetched HTML between test runs. This speeds up repeated
+// runs and reduces network requests when iterating on translators.
+const CACHE_DIR = join(ROOT_DIR, 'test_cache');
+try {
+    mkdirSync(CACHE_DIR, { recursive: true });
+} catch (e) {}
 
-async function run_on_file(filename) {
+function urlToCacheName(url) {
+    // base64url encode the URL to a safe filename
+    const b = Buffer.from(String(url || ''), 'utf8').toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    return b + '.html';
+}
+
+async function readCachedHtml(url) {
+    try {
+        const fname = join(CACHE_DIR, urlToCacheName(url));
+        if (existsSync(fname)) {
+            return await promises.readFile(fname, 'utf8');
+        }
+    } catch (e) {}
+    return null;
+}
+
+async function writeCachedHtml(url, html) {
+    try {
+        const fname = join(CACHE_DIR, urlToCacheName(url));
+        await promises.writeFile(fname, html, 'utf8');
+    } catch (e) {}
+}
+
+
+async function run_on_file(filename, singleTestIndex) {
     // Ensure DOMParser and a fetch implementation are available for translatorRunner
     let JSDOM;
     try {
-        JSDOM = require('jsdom').JSDOM;
+        const jsdomMod = await import('jsdom');
+        JSDOM = jsdomMod.JSDOM;
     } catch (e) {
         console.error('Please install jsdom: npm install jsdom');
         process.exit(1);
     }
     const dom = new JSDOM('<!doctype html><html><body></body></html>');
-    global.DOMParser = dom.window.DOMParser;
+    // Wrap jsdom's DOMParser so created documents get a usable `location`.
+    // The runner expects `doc.location.pathname` to be a string; cached HTML
+    // tests may not provide a proper location, so we inject the current
+    // test URL (stored in `global.__test_current_url`) when available.
+    const OriginalDOMParser = dom.window.DOMParser;
+    global.DOMParser = class DOMParserWrapper {
+        constructor() { this._p = new OriginalDOMParser(); }
+        parseFromString(str, type) {
+            const doc = this._p.parseFromString(str, type);
+            try {
+                const u = global.__test_current_url;
+                const loc = u ? new URL(String(u)) : { href: '', pathname: '' };
+
+                // Return a proxy that forwards to the real document but
+                // guarantees a usable `location` property so translators can
+                // safely access `doc.location.pathname`.
+                const proxy = new Proxy(doc, {
+                    get(target, prop, receiver) {
+                        if (prop === 'location') return loc;
+                        const val = Reflect.get(target, prop, receiver);
+                        return typeof val === 'function' ? val.bind(target) : val;
+                    },
+                    getOwnPropertyDescriptor(target, prop) {
+                        if (prop === 'location') return { configurable: true, enumerable: true, value: loc };
+                        return Reflect.getOwnPropertyDescriptor(target, prop);
+                    },
+                });
+                return proxy;
+            } catch (e) {
+                return doc;
+            }
+        }
+    };
     // Expose XPathResult from jsdom so xpath evaluation constants are available
     global.XPathResult = dom.window.XPathResult;
 
     // Dynamic import of the ES module translator runner
-    const trPath = path.join(__dirname, 'sources/translatorRunner.js');
+    const trPath = join(ROOT_DIR, 'sources', 'translatorRunner.js');
     const trModule = await import('file://' + trPath);
     const { runTranslatorOnHtml } = trModule;
 
     // Load ScienceDirect translator source and execute it in a sandbox so we can
     // read the `testCases` variable produced by the translator file.
-    const sdPath = path.join(__dirname, 'translators', 'zotero', filename);
-    const sdSrc = fs.readFileSync(sdPath, 'utf8');
+    const sdPath = join(ROOT_DIR, 'translators', 'zotero', filename);
+    const sdSrc = readFileSync(sdPath, 'utf8');
 
     const sandbox = { console, URL, window: {}, document: {}, DOMParser: global.DOMParser };
     // Minimal ZU shim for detection-time helpers (xpath, xpathText, text, trimInternal)
@@ -97,9 +164,9 @@ async function run_on_file(filename) {
         },
         trimInternal: (s) => (s || '').replace(/\s+/g, ' ').trim(),
     };
-    vm.createContext(sandbox);
+    createContext(sandbox);
     try {
-        vm.runInContext(sdSrc, sandbox, { filename: filename });
+        runInContext(sdSrc, sandbox, { filename: filename });
     } catch (e) {
         // Some translators reference globals at load time; warn but continue
         console.warn('Warning: executing translator source threw:', e && e.message);
@@ -129,30 +196,71 @@ async function run_on_file(filename) {
     const sdFileUrl = 'file://' + sdPath;
 
     console.log('Found', testCases.length, 'test cases');
-    test_id = 0;
-    
-    for (const tc of testCases) {
-        test_id++;
-        if (!tc || tc.type !== 'web' || tc.items == "multiple") continue;
+    let test_id = 0;
+
+    for (let i = 0; i < testCases.length; i++) {
+        const tc = testCases[i];
+        if (tc.type === 'search') {
+            console.error("arXiv: Skip category.");
+            continue;
+        }
+
+        const position = i + 1;
+
+        // If a single test index was requested, skip others
+        if (singleTestIndex && position !== singleTestIndex) continue;
+
+        test_id = position;
+
+        if (!tc) continue;
+
+        // If the requested single test is not runnable, report and exit early
+        // if (singleTestIndex && (tc.type !== 'web' || tc.items == "multiple")) {
+        //     console.error(`Selected test #${position} is not runnable (type: ${tc.type}, items: ${tc.items})`);
+        //     return;
+        // }
+
+        // if (tc.type !== 'web' || tc.items == "multiple") continue;
         const url = tc.url;
         console.log(`\n=== Test case #${test_id}/${testCases.length}: ${url} ===`);
         try {
-            const res = await fetch(url, { redirect: 'follow' });
-            const html = await res.text();
+            if (url.includes("arxiv.org/") && (url.includes("find/") || tc.type === 'search')) {
+                console.error("arXiv: Legacy Find has been shut off.");
+                continue;
+            }
+            // Try cache first to avoid refetching the same page across runs
+            let html = await readCachedHtml(url);
+            if (!html) {
+                const res = await fetch(url, { redirect: 'follow' });
+                html = await res.text();
+                // Cache successful fetches for reuse
+                try { await writeCachedHtml(url, html); } catch (e) {}
+            }
+            console.log(`Running translator on cached file: ${urlToCacheName(url)}`);
+            // Expose the current test URL so our DOMParser wrapper can set
+            // `doc.location` before the translator runs.
+            try {
+                global.__test_current_url = url;
+            } catch (e) {}
             const out = await runTranslatorOnHtml(sdFileUrl, html, url);
+            try { delete global.__test_current_url; } catch (e) {}
             if (!out) {
                 throw new Error('No output from translator');
-                break;
             }
-            console.log('Result:', typeof out === 'string' ? out.slice(0, 1000) : JSON.stringify(out, null, 2));
+            // console.log('Result:', typeof out === 'string' ? out.slice(0, 1000) : JSON.stringify(out, null, 2));
         } catch (e) {
             console.error('Error processing', url, e && e.message);
+            // Some translators return "multiple" during detection; the
+            // runner doesn't support multi-select execution. Treat that
+            // as an expected outcome when the test case expects multiple
+            // items and continue to the next test instead of aborting.
+            if (e && e.message && e.message.includes('multi-select not supported') && tc.items === 'multiple') {
+                console.log('Translator reported multiple items (expected) — skipping execution');
+                continue;
+            }
             if (e.message == "Could not scrape metadata via known methods") {
                 console.error("Skip this test due to translator inability to scrape metadata.");
-            } else if (url.includes("arxiv.org/") && (url.includes("list/") || url.includes("search/") || url.includes("find/"))) {
-                console.error("Skip this test due to arXiv multiple items page.");
-            }
-            else {
+            } else {
                 break;
             }
         }
@@ -163,24 +271,57 @@ async function run_on_file(filename) {
 const args = process.argv.slice(2);
 if (args.length >= 1) {
     const filename = args[0];
-    run_on_file(filename).catch(e => {
+    const indexArg = args[1];
+    let singleTestIndex = null;
+    if (typeof indexArg !== 'undefined') {
+        singleTestIndex = parseInt(indexArg, 10);
+        if (!Number.isInteger(singleTestIndex) || singleTestIndex < 1) {
+            console.error('Invalid test index. Provide a 1-based positive integer as second argument.');
+            process.exit(1);
+        }
+    }
+    run_on_file(filename, singleTestIndex).catch(e => {
         console.error('Fatal error:', e);
         process.exit(1);
     });
 } else {
     // No argument: run on all test files in translators/zotero
-    const translatorsDir = path.join(__dirname, 'translators', 'zotero');
-    fs.readdir(translatorsDir, (err, files) => {
+    const translatorsDir = join(ROOT_DIR, 'translators', 'zotero');
+    readdir(translatorsDir, (err, files) => {
         if (err) {
             console.error('Failed to read translators directory:', err);
             process.exit(1);
         }
         const jsFiles = files.filter(f => f.endsWith('.js'));
         (async () => {
-            for (const f of jsFiles) {
-                console.log(`\n\n######## Running tests for translator file: ${f} ########`);
-                await run_on_file(f);
-            }
+            // Run translator test files in parallel with bounded concurrency to
+            // avoid overwhelming the machine or network. Default concurrency=4.
+            const concurrency = 4;
+            let idx = 0;
+            const results = [];
+
+            const worker = async () => {
+                while (true) {
+                    let cur;
+                    // simple atomic fetch
+                    if (idx >= jsFiles.length) return;
+                    cur = jsFiles[idx++];
+                    console.log(`\n\n######## Running tests for translator file: ${cur} ########`);
+                    try {
+                        await run_on_file(cur);
+                        results.push({ file: cur, ok: true });
+                    } catch (e) {
+                        console.error('Fatal error while running', cur, e);
+                        results.push({ file: cur, ok: false, error: e });
+                    }
+                }
+            };
+
+            const workers = Array.from({ length: Math.min(concurrency, jsFiles.length) }, () => worker());
+            await Promise.all(workers);
+            // Optionally inspect results to decide exit code
+            const failed = results.find(r => !r.ok);
+            if (failed) process.exit(1);
         })().catch(e => {
             console.error('Fatal error:', e);
             process.exit(1);


### PR DESCRIPTION
### **User description**
This helps when running the tests locally, to avoid pulling from the various websites, and speeding up the process. The tests run in parallel in vm environments.

Doesn't modify anything in the extension.

Might be a good idea to keep some cached in the repo for the tests (so we don't pull from arxiv every time)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Convert test runner to ES modules with improved caching

- Add local HTML cache to avoid repeated network requests

- Implement parallel test execution with bounded concurrency

- Support single test execution via command-line index argument

- Enhance DOMParser wrapper for proper document location handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["test.js<br/>CommonJS"] -->|"Convert to ESM"| B["test.js<br/>ES Modules"]
  B -->|"Add caching layer"| C["Cache System<br/>test_cache/"]
  B -->|"Implement workers"| D["Parallel Execution<br/>Bounded Concurrency"]
  C -->|"Reduce network<br/>requests"| E["Faster Test Runs"]
  D -->|"Run tests in<br/>parallel"| E
  B -->|"Wrap DOMParser"| F["Enhanced DOM<br/>Location Handling"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test.js</strong><dd><code>Convert to ESM, add caching, enable parallel execution</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test.js

<ul><li>Convert from CommonJS (<code>require</code>) to ES modules (<code>import</code>) with <br>ESM-compatible root directory detection<br> <li> Add <code>CACHE_DIR</code> and caching functions (<code>readCachedHtml</code>, <code>writeCachedHtml</code>, <br><code>urlToCacheName</code>) to store fetched HTML locally and avoid repeated <br>network requests<br> <li> Implement parallel test execution with bounded concurrency (default 4 <br>workers) when running all translator tests<br> <li> Add support for single test execution via optional command-line index <br>argument to <code>run_on_file</code><br> <li> Wrap jsdom's DOMParser to inject proper <code>location</code> property for cached <br>HTML documents<br> <li> Enhance error handling for arXiv legacy endpoints and multi-select <br>translator responses<br> <li> Add <code>singleTestIndex</code> parameter to <code>run_on_file</code> function for targeted <br>test execution</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/JabRef-Browser-Extension-fresh/pull/15/files#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60">+176/-35</a></td>

</tr>
</table></td></tr></tbody></table>

</details>

___

