### PR TITLE
Open JabRef with a url handler

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -139,6 +139,32 @@ function getBaseUrl() {
   });
 }
 
+// Open the jabref:// protocol handler and wait until the HTTP server becomes reachable.
+async function openJabRefAndWait(base, { timeout = 10000, interval = 1000 } = {}) {
+  // Try to navigate to the protocol URL to trigger JabRef
+  if (window.chrome && chrome.tabs && chrome.tabs.update) {
+    try {
+      await new Promise((resolve) =>
+        chrome.tabs.update({ url: "jabref://", active: false }, () => resolve()),
+      );
+    } catch (e) {
+      console.warn("chrome.tabs.update failed", e);
+    }
+  }
+
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    try {
+      const resp = await fetch(base, { method: "GET", cache: "no-store" });
+      if (resp && (resp.ok || resp.status === 404)) return true;
+    } catch (e) {
+      // still waiting
+    }
+    await new Promise((r) => setTimeout(r, interval));
+  }
+  return false;
+}
+
 async function connectToJabRef() {
   const base = await getBaseUrl();
   if (!base) {
@@ -165,6 +191,15 @@ async function connectToJabRef() {
     console.error("HTTP connection error:", error);
     updateStatus("Disconnected", "disconnected");
     jabrefBaseUrl = null;
+    appendLog("Attempting to open JabRef via protocol handler...", "info");
+    const opened = await openJabRefAndWait(base, { timeout: 15000, interval: 1000 });
+    if (opened) {
+      appendLog("Detected JabRef after protocol handler open", "success");
+      updateStatus("Connected", "connected");
+      jabrefBaseUrl = base;
+      return true;
+    }
+    appendLog("Timed out waiting for JabRef after opening protocol handler", "error");
     return false;
   }
   return true;


### PR DESCRIPTION
### **User description**
Proof of concept.

This needs a slight change in the jabref packaging, then we can use it to call jabref as a url handler.
Currently it could be used to start the program if not already active.

In theory this might make it so we can pass any cli arguments using the url handler. Asks for a permission on first run but can then be registered.

At the moment it's a bit flaky on whether it imports the bib item after starting, but should be fixable by just moving some code around.


___

### **PR Type**
Enhancement


___

### **Description**
- Add protocol handler support to launch JabRef via jabref:// URL

- Implement automatic retry mechanism with polling to detect JabRef startup

- Fallback to protocol handler when HTTP connection fails initially

- Configurable timeout and polling interval for server availability checks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Connection attempt"] --> B{"HTTP connection<br/>successful?"}
  B -->|Yes| C["Connected to JabRef"]
  B -->|No| D["Trigger jabref://<br/>protocol handler"]
  D --> E["Poll HTTP server<br/>with timeout"]
  E --> F{"Server<br/>reachable?"}
  F -->|Yes| C
  F -->|No| G["Connection timeout"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>popup.js</strong><dd><code>Add protocol handler launch with server polling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

popup.js

<ul><li>Added <code>openJabRefAndWait()</code> function to trigger JabRef via protocol <br>handler and poll for server availability<br> <li> Implements configurable timeout (default 10s) and polling interval <br>(default 1s) for HTTP server detection<br> <li> Modified <code>connectToJabRef()</code> to attempt protocol handler launch when <br>initial HTTP connection fails<br> <li> Provides user feedback via logging when attempting protocol handler <br>and connection outcomes</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/JabRef-Browser-Extension-fresh/pull/18/files#diff-3df6958c77d615b266b54fcf12fadf313e7c1e4b168f0c61ea8c3424eb39eb8c">+35/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

